### PR TITLE
Make code less ugly

### DIFF
--- a/lib/rubyversionofunboundedstackimpl.rb
+++ b/lib/rubyversionofunboundedstackimpl.rb
@@ -28,9 +28,9 @@ class RubyVersion_ofDotNet_UnboundedStackImpl
 
   def top; raise "Cannot Top an empty Stack" if empty?; @listOfStackElements.last; end
 
-  def RaiseError(theMessageToRaise) raise theMessageToRaise || return; puts "Message raised: #{theMessageToRaise}"; end
-
   private
+
+  def RaiseError(theMessageToRaise) raise theMessageToRaise || return; puts "Message raised: #{theMessageToRaise}"; end
 
   def pop_the_Stack
     tmpStackVar = @listOfStackElements.clone

--- a/lib/rubyversionofunboundedstackimpl.rb
+++ b/lib/rubyversionofunboundedstackimpl.rb
@@ -20,7 +20,7 @@ class RubyVersion_ofDotNet_UnboundedStackImpl
 
   def pop
     unless empty? == false
-    then self.RaiseError("Cannot Pop an empty Stack")
+    then self.raise_error("Cannot Pop an empty Stack")
     else
       pop_the_Stack
     end;
@@ -30,7 +30,10 @@ class RubyVersion_ofDotNet_UnboundedStackImpl
 
   private
 
-  def RaiseError(theMessageToRaise) raise theMessageToRaise || return; puts "Message raised: #{theMessageToRaise}"; end
+  def raise_error(theMessageToRaise)
+    raise theMessageToRaise || return
+    puts "Message raised: #{theMessageToRaise}"
+  end
 
   def pop_the_Stack
     tmpStackVar = @listOfStackElements.clone

--- a/lib/rubyversionofunboundedstackimpl.rb
+++ b/lib/rubyversionofunboundedstackimpl.rb
@@ -1,66 +1,66 @@
 
 class RubyVersion_ofDotNet_UnboundedStackImpl
 
-def empty?
-unless @listOfStackElements != nil
-@listOfStackElements = Array.new
-end; self.instance_variable_get('@listOfStackElements').empty?
-end
+  def empty?
+    unless @listOfStackElements != nil
+      @listOfStackElements = Array.new
+    end; self.instance_variable_get('@listOfStackElements').empty?
+  end
 
-def push a
-element_toPushOnTOstack = a
-if @listOfStackElements == nil
-@listOfStackElements = Array.new
-end
-tmpArrayVar = @listOfStackElements.dup()
-tmpArrayVar = tmpArrayVar[0..(@listOfStackElements.length)] + [element_toPushOnTOstack]
-(RubyVersion_ofDotNet_UnboundedStackImpl).instance_eval { instance_variable_set('@listOfStackElements', tmpArrayVar) }; @listOfStackElements = tmpArrayVar
-return '42'
-end
+  def push a
+    element_toPushOnTOstack = a
+    if @listOfStackElements == nil
+      @listOfStackElements = Array.new
+    end
+    tmpArrayVar = @listOfStackElements.dup()
+    tmpArrayVar = tmpArrayVar[0..(@listOfStackElements.length)] + [element_toPushOnTOstack]
+    (RubyVersion_ofDotNet_UnboundedStackImpl).instance_eval { instance_variable_set('@listOfStackElements', tmpArrayVar) }; @listOfStackElements = tmpArrayVar
+    return '42'
+  end
 
-def pop
-unless empty? == false
-then self.RaiseError("Cannot Pop an empty Stack")
-else
-pop_the_Stack
-end;
-end
+  def pop
+    unless empty? == false
+    then self.RaiseError("Cannot Pop an empty Stack")
+    else
+      pop_the_Stack
+    end;
+  end
 
-def top; raise "Cannot Top an empty Stack" if empty?; @listOfStackElements.last; end
+  def top; raise "Cannot Top an empty Stack" if empty?; @listOfStackElements.last; end
 
-def RaiseError(theMessageToRaise) raise theMessageToRaise || return; puts "Message raised: #{theMessageToRaise}"; end
+  def RaiseError(theMessageToRaise) raise theMessageToRaise || return; puts "Message raised: #{theMessageToRaise}"; end
 
-private
+  private
 
-def pop_the_Stack
-tmpStackVar = @listOfStackElements.clone
-top_of_the_stack = nil
-while !tmpStackVar[0].nil?
-top_of_the_stack = tmpStackVar[0]
-for i in 0..tmpStackVar.length do  # [a, b, c]  => [b, c] top=b, => [c] top = c, 
-tmpStackVar[i] = tmpStackVar[i+1]
-end
-end
-@listOfStackElements = lessOne(@listOfStackElements, top_of_the_stack)
-return top_of_the_stack
-end
+  def pop_the_Stack
+    tmpStackVar = @listOfStackElements.clone
+    top_of_the_stack = nil
+    while !tmpStackVar[0].nil?
+      top_of_the_stack = tmpStackVar[0]
+      for i in 0..tmpStackVar.length do  # [a, b, c]  => [b, c] top=b, => [c] top = c,
+        tmpStackVar[i] = tmpStackVar[i+1]
+      end
+    end
+    @listOfStackElements = lessOne(@listOfStackElements, top_of_the_stack)
+    return top_of_the_stack
+  end
 
 
-def lessOne(some_Arr, some_Var)
-some_r = Array.new
-some_r = some_Arr.reverse if !some_Arr.empty?
-new_r = Array.new
-return nil if some_Arr.length == 0
-skip = true
-x = 0
-for i in 0..some_r.length-1 do
-if skip then
-skip = false
-next
-end
-(new_r[x] = some_r[i]) && x = x + 1
-end
-return new_r.reverse || nil
-end
+  def lessOne(some_Arr, some_Var)
+    some_r = Array.new
+    some_r = some_Arr.reverse if !some_Arr.empty?
+    new_r = Array.new
+    return nil if some_Arr.length == 0
+    skip = true
+    x = 0
+    for i in 0..some_r.length-1 do
+      if skip then
+        skip = false
+        next
+      end
+      (new_r[x] = some_r[i]) && x = x + 1
+    end
+    return new_r.reverse || nil
+  end
 
 end

--- a/lib/rubyversionofunboundedstackimpl.rb
+++ b/lib/rubyversionofunboundedstackimpl.rb
@@ -2,21 +2,20 @@
 class RubyVersion_ofDotNet_UnboundedStackImpl
 
   def empty?
-    unless @listOfStackElements != nil
-      @listOfStackElements = Array.new
+    unless list_of_stack_elements != nil
+      self.list_of_stack_elements = Array.new
     end
-    self.instance_variable_get('@listOfStackElements').empty?
+    list_of_stack_elements.empty?
   end
 
   def push a
     element_toPushOnTOstack = a
-    if @listOfStackElements == nil
-      @listOfStackElements = Array.new
+    if list_of_stack_elements == nil
+      self.list_of_stack_elements = Array.new
     end
-    tmpArrayVar = @listOfStackElements.dup()
-    tmpArrayVar = tmpArrayVar[0..(@listOfStackElements.length)] + [element_toPushOnTOstack]
-    (RubyVersion_ofDotNet_UnboundedStackImpl).instance_eval { instance_variable_set('@listOfStackElements', tmpArrayVar) }
-    @listOfStackElements = tmpArrayVar
+    tmpArrayVar = list_of_stack_elements.dup()
+    tmpArrayVar = tmpArrayVar[0..(list_of_stack_elements.length)] + [element_toPushOnTOstack]
+    self.list_of_stack_elements = tmpArrayVar
     return '42'
   end
 
@@ -31,10 +30,12 @@ class RubyVersion_ofDotNet_UnboundedStackImpl
 
   def top
     raise "Cannot Top an empty Stack" if empty?
-    @listOfStackElements.last
+    list_of_stack_elements.last
   end
 
   private
+
+  attr_accessor :list_of_stack_elements
 
   def raise_error(theMessageToRaise)
     raise theMessageToRaise || return
@@ -42,7 +43,7 @@ class RubyVersion_ofDotNet_UnboundedStackImpl
   end
 
   def pop_the_Stack
-    tmpStackVar = @listOfStackElements.clone
+    tmpStackVar = list_of_stack_elements.clone
     top_of_the_stack = nil
     while !tmpStackVar[0].nil?
       top_of_the_stack = tmpStackVar[0]
@@ -50,7 +51,7 @@ class RubyVersion_ofDotNet_UnboundedStackImpl
         tmpStackVar[i] = tmpStackVar[i+1]
       end
     end
-    @listOfStackElements = lessOne(@listOfStackElements, top_of_the_stack)
+    self.list_of_stack_elements = lessOne(list_of_stack_elements, top_of_the_stack)
     return top_of_the_stack
   end
 

--- a/lib/rubyversionofunboundedstackimpl.rb
+++ b/lib/rubyversionofunboundedstackimpl.rb
@@ -4,7 +4,8 @@ class RubyVersion_ofDotNet_UnboundedStackImpl
   def empty?
     unless @listOfStackElements != nil
       @listOfStackElements = Array.new
-    end; self.instance_variable_get('@listOfStackElements').empty?
+    end
+    self.instance_variable_get('@listOfStackElements').empty?
   end
 
   def push a
@@ -14,7 +15,8 @@ class RubyVersion_ofDotNet_UnboundedStackImpl
     end
     tmpArrayVar = @listOfStackElements.dup()
     tmpArrayVar = tmpArrayVar[0..(@listOfStackElements.length)] + [element_toPushOnTOstack]
-    (RubyVersion_ofDotNet_UnboundedStackImpl).instance_eval { instance_variable_set('@listOfStackElements', tmpArrayVar) }; @listOfStackElements = tmpArrayVar
+    (RubyVersion_ofDotNet_UnboundedStackImpl).instance_eval { instance_variable_set('@listOfStackElements', tmpArrayVar) }
+    @listOfStackElements = tmpArrayVar
     return '42'
   end
 
@@ -23,10 +25,14 @@ class RubyVersion_ofDotNet_UnboundedStackImpl
     then self.raise_error("Cannot Pop an empty Stack")
     else
       pop_the_Stack
-    end;
+    end
+
   end
 
-  def top; raise "Cannot Top an empty Stack" if empty?; @listOfStackElements.last; end
+  def top
+    raise "Cannot Top an empty Stack" if empty?
+    @listOfStackElements.last
+  end
 
   private
 

--- a/lib/unbounded_stack.rb
+++ b/lib/unbounded_stack.rb
@@ -1,5 +1,5 @@
 
-class RubyVersion_ofDotNet_UnboundedStackImpl
+class UnboundedStack
 
   def empty?
     unless list_of_stack_elements != nil

--- a/lib/unbounded_stack.rb
+++ b/lib/unbounded_stack.rb
@@ -1,18 +1,16 @@
 
 class UnboundedStack
 
+  def initialize
+    self.list_of_stack_elements = Array.new
+  end
+
   def empty?
-    unless list_of_stack_elements != nil
-      self.list_of_stack_elements = Array.new
-    end
     list_of_stack_elements.empty?
   end
 
   def push a
     element_toPushOnTOstack = a
-    if list_of_stack_elements == nil
-      self.list_of_stack_elements = Array.new
-    end
     tmpArrayVar = list_of_stack_elements.dup()
     tmpArrayVar = tmpArrayVar[0..(list_of_stack_elements.length)] + [element_toPushOnTOstack]
     self.list_of_stack_elements = tmpArrayVar

--- a/lib/unbounded_stack.rb
+++ b/lib/unbounded_stack.rb
@@ -9,12 +9,8 @@ class UnboundedStack
     list_of_stack_elements.empty?
   end
 
-  def push a
-    element_toPushOnTOstack = a
-    tmpArrayVar = list_of_stack_elements.dup()
-    tmpArrayVar = tmpArrayVar[0..(list_of_stack_elements.length)] + [element_toPushOnTOstack]
-    self.list_of_stack_elements = tmpArrayVar
-    return '42'
+  def push new_element
+    list_of_stack_elements.push(new_element)
   end
 
   def pop

--- a/lib/unbounded_stack.rb
+++ b/lib/unbounded_stack.rb
@@ -1,6 +1,5 @@
 
 class UnboundedStack
-
   def initialize
     self.list_of_stack_elements = Array.new
   end
@@ -29,7 +28,9 @@ class UnboundedStack
   attr_accessor :list_of_stack_elements
 
   def raise_error(theMessageToRaise)
-    raise theMessageToRaise || return
+    return unless theMessageToRaise
+
     puts "Message raised: #{theMessageToRaise}"
+    raise theMessageToRaise
   end
 end

--- a/lib/unbounded_stack.rb
+++ b/lib/unbounded_stack.rb
@@ -16,7 +16,7 @@ class UnboundedStack
   def pop
     raise_error("Cannot Pop an empty Stack") if empty?
 
-    pop_the_stack
+    list_of_stack_elements.pop
   end
 
   def top
@@ -32,36 +32,4 @@ class UnboundedStack
     raise theMessageToRaise || return
     puts "Message raised: #{theMessageToRaise}"
   end
-
-  def pop_the_stack
-    tmpStackVar = list_of_stack_elements.clone
-    top_of_the_stack = nil
-    while !tmpStackVar[0].nil?
-      top_of_the_stack = tmpStackVar[0]
-      for i in 0..tmpStackVar.length do  # [a, b, c]  => [b, c] top=b, => [c] top = c,
-        tmpStackVar[i] = tmpStackVar[i+1]
-      end
-    end
-    self.list_of_stack_elements = lessOne(list_of_stack_elements, top_of_the_stack)
-    return top_of_the_stack
-  end
-
-
-  def lessOne(some_Arr, some_Var)
-    some_r = Array.new
-    some_r = some_Arr.reverse if !some_Arr.empty?
-    new_r = Array.new
-    return nil if some_Arr.length == 0
-    skip = true
-    x = 0
-    for i in 0..some_r.length-1 do
-      if skip then
-        skip = false
-        next
-      end
-      (new_r[x] = some_r[i]) && x = x + 1
-    end
-    return new_r.reverse || nil
-  end
-
 end

--- a/lib/unbounded_stack.rb
+++ b/lib/unbounded_stack.rb
@@ -18,12 +18,9 @@ class UnboundedStack
   end
 
   def pop
-    unless empty? == false
-    then self.raise_error("Cannot Pop an empty Stack")
-    else
-      pop_the_Stack
-    end
+    raise_error("Cannot Pop an empty Stack") if empty?
 
+    pop_the_stack
   end
 
   def top
@@ -40,7 +37,7 @@ class UnboundedStack
     puts "Message raised: #{theMessageToRaise}"
   end
 
-  def pop_the_Stack
+  def pop_the_stack
     tmpStackVar = list_of_stack_elements.clone
     top_of_the_stack = nil
     while !tmpStackVar[0].nil?

--- a/lib/unbounded_stack.rb
+++ b/lib/unbounded_stack.rb
@@ -9,17 +9,17 @@ class UnboundedStack
   end
 
   def push new_element
-    list_of_stack_elements.push(new_element)
+    list_of_stack_elements.push new_element
   end
 
   def pop
-    raise_error("Cannot Pop an empty Stack") if empty?
+    raise_error "Cannot Pop an empty Stack" if empty?
 
     list_of_stack_elements.pop
   end
 
   def top
-    raise "Cannot Top an empty Stack" if empty?
+    raise_error "Cannot Top an empty Stack" if empty?
     list_of_stack_elements.last
   end
 

--- a/spec/ruby_version_of_dot_net_unbounded_stack_spec.rb
+++ b/spec/ruby_version_of_dot_net_unbounded_stack_spec.rb
@@ -1,7 +1,7 @@
-require 'rubyversionofunboundedstackimpl'
+require 'unbounded_stack'
 
-describe 'RubyVersion_ofDotNet_UnboundedStackImpl' do
-  subject(:stack) { RubyVersion_ofDotNet_UnboundedStackImpl.new }
+describe 'UnboundedStack' do
+  subject(:stack) { UnboundedStack.new }
 
   specify "1. Create a Stack and verifies that IsEmpty is true." do
     expect(stack.empty?).to be(true)


### PR DESCRIPTION
Mostly, this cleans up ruby style violations.

We left in an explicit delegation to `list_of_stack_elements`, but that's an easy thing to remove later by inheriting from `Array`.
- removed a lot of unused code
- removed a lot of unnecessary and confusing stuff as wel
